### PR TITLE
Add browser image cropper for PNG to JPG conversion

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,449 @@
+const fileInput = document.getElementById('fileInput');
+const maxDimensionInput = document.getElementById('maxDimension');
+const baseNameInput = document.getElementById('baseName');
+const startIndexInput = document.getElementById('startIndex');
+const downloadButton = document.getElementById('downloadAll');
+const imagesContainer = document.getElementById('imagesContainer');
+const imageTemplate = document.getElementById('imageTemplate');
+
+const MIN_CROP_PIXELS = 1;
+
+const state = {
+  items: [],
+};
+
+fileInput.addEventListener('change', (event) => {
+  const files = Array.from(event.target.files || []);
+  files.forEach((file) => {
+    if (!file.type.startsWith('image/')) {
+      return;
+    }
+    loadImageFile(file);
+  });
+  fileInput.value = '';
+});
+
+downloadButton.addEventListener('click', handleDownloadAll);
+
+function loadImageFile(file) {
+  const reader = new FileReader();
+  reader.onload = () => {
+    const img = new Image();
+    img.onload = () => {
+      const autoOffsets = detectAutoOffsets(img);
+      const item = {
+        id: crypto.randomUUID ? crypto.randomUUID() : `${Date.now()}-${Math.random()}`,
+        file,
+        image: img,
+        width: img.naturalWidth,
+        height: img.naturalHeight,
+        autoOffsets: { ...autoOffsets },
+        offsets: { ...autoOffsets },
+        isManual: false,
+      };
+
+      createImageCard(item);
+      state.items.push(item);
+      updateDownloadButtonState();
+      updatePreview(item);
+    };
+    img.onerror = () => {
+      console.error('Не удалось прочитать изображение:', file.name);
+    };
+    img.src = reader.result;
+  };
+  reader.onerror = () => {
+    console.error('Ошибка чтения файла', reader.error);
+  };
+  reader.readAsDataURL(file);
+}
+
+function detectAutoOffsets(image) {
+  const width = image.naturalWidth;
+  const height = image.naturalHeight;
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext('2d', { willReadFrequently: true });
+  ctx.drawImage(image, 0, 0);
+  const { data } = ctx.getImageData(0, 0, width, height);
+
+  const whiteThreshold = 245;
+  const tolerance = 0.97;
+  const sampleX = Math.max(1, Math.floor(width / 600));
+  const sampleY = Math.max(1, Math.floor(height / 600));
+
+  const pixelIsWhite = (x, y) => {
+    const index = (y * width + x) * 4;
+    const r = data[index];
+    const g = data[index + 1];
+    const b = data[index + 2];
+    return r >= whiteThreshold && g >= whiteThreshold && b >= whiteThreshold;
+  };
+
+  const rowIsWhite = (y) => {
+    let total = 0;
+    let white = 0;
+    for (let x = 0; x < width; x += sampleX) {
+      total += 1;
+      if (pixelIsWhite(x, y)) {
+        white += 1;
+      }
+    }
+    if ((width - 1) % sampleX !== 0) {
+      total += 1;
+      if (pixelIsWhite(width - 1, y)) {
+        white += 1;
+      }
+    }
+    return white / total >= tolerance;
+  };
+
+  const columnIsWhite = (x) => {
+    let total = 0;
+    let white = 0;
+    for (let y = 0; y < height; y += sampleY) {
+      total += 1;
+      if (pixelIsWhite(x, y)) {
+        white += 1;
+      }
+    }
+    if ((height - 1) % sampleY !== 0) {
+      total += 1;
+      if (pixelIsWhite(x, height - 1)) {
+        white += 1;
+      }
+    }
+    return white / total >= tolerance;
+  };
+
+  let top = 0;
+  while (top < height && rowIsWhite(top)) top += 1;
+
+  let bottom = height - 1;
+  while (bottom >= top && rowIsWhite(bottom)) bottom -= 1;
+
+  let left = 0;
+  while (left < width && columnIsWhite(left)) left += 1;
+
+  let right = width - 1;
+  while (right >= left && columnIsWhite(right)) right -= 1;
+
+  if (left >= right) {
+    left = 0;
+    right = width - 1;
+  }
+
+  if (top >= bottom) {
+    top = 0;
+    bottom = height - 1;
+  }
+
+  const margin = Math.round(Math.min(width, height) * 0.005);
+
+  const topOffset = clamp(top - margin, 0, height - 1);
+  const bottomOffset = clamp(height - 1 - bottom - margin, 0, height - 1);
+  const leftOffset = clamp(left - margin, 0, width - 1);
+  const rightOffset = clamp(width - 1 - right - margin, 0, width - 1);
+
+  return {
+    top: topOffset,
+    bottom: bottomOffset,
+    left: leftOffset,
+    right: rightOffset,
+  };
+}
+
+function createImageCard(item) {
+  const fragment = imageTemplate.content.cloneNode(true);
+  const card = fragment.querySelector('.image-card');
+  const title = fragment.querySelector('.image-card__title');
+  const subtitle = fragment.querySelector('.image-card__subtitle');
+  const previewCanvas = fragment.querySelector('.preview');
+  const previewSize = fragment.querySelector('.preview-size');
+  const manualToggle = fragment.querySelector('.manual-toggle');
+  const slidersBlock = fragment.querySelector('.sliders');
+  const sliderTop = fragment.querySelector('.slider-top');
+  const sliderBottom = fragment.querySelector('.slider-bottom');
+  const sliderLeft = fragment.querySelector('.slider-left');
+  const sliderRight = fragment.querySelector('.slider-right');
+  const valueTop = fragment.querySelector('.value-top');
+  const valueBottom = fragment.querySelector('.value-bottom');
+  const valueLeft = fragment.querySelector('.value-left');
+  const valueRight = fragment.querySelector('.value-right');
+  const resetButton = fragment.querySelector('.reset-auto');
+  const removeButton = fragment.querySelector('.remove-btn');
+
+  title.textContent = item.file.name;
+  subtitle.textContent = `Исходный размер: ${item.width} × ${item.height} px`;
+  previewSize.textContent = '';
+
+  const sliderElements = [sliderTop, sliderBottom, sliderLeft, sliderRight];
+  sliderElements.forEach((slider) => {
+    slider.min = '0';
+    slider.max = String(slider === sliderTop || slider === sliderBottom ? item.height - 1 : item.width - 1);
+    slider.disabled = true;
+  });
+
+  manualToggle.addEventListener('change', () => {
+    setManualMode(item, manualToggle.checked);
+  });
+
+  const sliderHandler = (side, slider) => {
+    slider.addEventListener('input', () => {
+      if (!item.isManual) {
+        return;
+      }
+      applyOffsetChange(item, side, Number(slider.value));
+    });
+  };
+
+  sliderHandler('top', sliderTop);
+  sliderHandler('bottom', sliderBottom);
+  sliderHandler('left', sliderLeft);
+  sliderHandler('right', sliderRight);
+
+  resetButton.addEventListener('click', () => {
+    const autoOffsets = detectAutoOffsets(item.image);
+    item.autoOffsets = { ...autoOffsets };
+    item.offsets = { ...autoOffsets };
+    manualToggle.checked = false;
+    setManualMode(item, false);
+    updatePreview(item);
+  });
+
+  removeButton.addEventListener('click', () => {
+    removeImageItem(item.id);
+  });
+
+  card.dataset.id = item.id;
+
+  item.elements = {
+    card,
+    subtitle,
+    previewCanvas,
+    previewSize,
+    manualToggle,
+    slidersBlock,
+    sliders: {
+      top: sliderTop,
+      bottom: sliderBottom,
+      left: sliderLeft,
+      right: sliderRight,
+    },
+    values: {
+      top: valueTop,
+      bottom: valueBottom,
+      left: valueLeft,
+      right: valueRight,
+    },
+  };
+
+  imagesContainer.appendChild(fragment);
+  updateSliderUI(item);
+}
+
+function setManualMode(item, manual) {
+  item.isManual = manual;
+  const { slidersBlock, sliders, manualToggle } = item.elements;
+  slidersBlock.hidden = !manual;
+  Object.values(sliders).forEach((slider) => {
+    slider.disabled = !manual;
+  });
+
+  if (!manual) {
+    item.offsets = { ...item.autoOffsets };
+  }
+
+  manualToggle.checked = manual;
+  updateSliderUI(item);
+  updatePreview(item);
+}
+
+function applyOffsetChange(item, side, value) {
+  const { offsets } = item;
+  const maxValue = side === 'top' || side === 'bottom' ? item.height - 1 : item.width - 1;
+  offsets[side] = clamp(Math.round(value), 0, maxValue);
+
+  const cropWidth = item.width - offsets.left - offsets.right;
+  if (cropWidth < MIN_CROP_PIXELS) {
+    if (side === 'left') {
+      offsets.right = clamp(item.width - MIN_CROP_PIXELS - offsets.left, 0, item.width - 1);
+    } else if (side === 'right') {
+      offsets.left = clamp(item.width - MIN_CROP_PIXELS - offsets.right, 0, item.width - 1);
+    }
+  }
+
+  const cropHeight = item.height - offsets.top - offsets.bottom;
+  if (cropHeight < MIN_CROP_PIXELS) {
+    if (side === 'top') {
+      offsets.bottom = clamp(item.height - MIN_CROP_PIXELS - offsets.top, 0, item.height - 1);
+    } else if (side === 'bottom') {
+      offsets.top = clamp(item.height - MIN_CROP_PIXELS - offsets.bottom, 0, item.height - 1);
+    }
+  }
+
+  updateSliderUI(item);
+  updatePreview(item);
+}
+
+function updateSliderUI(item) {
+  const { offsets } = item;
+  const { sliders, values } = item.elements;
+
+  sliders.top.value = String(offsets.top);
+  sliders.bottom.value = String(offsets.bottom);
+  sliders.left.value = String(offsets.left);
+  sliders.right.value = String(offsets.right);
+
+  values.top.textContent = offsets.top;
+  values.bottom.textContent = offsets.bottom;
+  values.left.textContent = offsets.left;
+  values.right.textContent = offsets.right;
+}
+
+function updatePreview(item) {
+  const { previewCanvas, previewSize } = item.elements;
+  const { offsets } = item;
+
+  const cropWidth = Math.max(1, item.width - offsets.left - offsets.right);
+  const cropHeight = Math.max(1, item.height - offsets.top - offsets.bottom);
+
+  const maxPreviewSide = 320;
+  const scale = Math.min(1, maxPreviewSide / Math.max(cropWidth, cropHeight));
+  const canvasWidth = Math.max(1, Math.round(cropWidth * scale));
+  const canvasHeight = Math.max(1, Math.round(cropHeight * scale));
+
+  previewCanvas.width = canvasWidth;
+  previewCanvas.height = canvasHeight;
+  previewCanvas.style.width = '100%';
+  previewCanvas.style.height = 'auto';
+  previewCanvas.style.aspectRatio = `${cropWidth} / ${cropHeight}`;
+
+  const ctx = previewCanvas.getContext('2d');
+  ctx.clearRect(0, 0, canvasWidth, canvasHeight);
+  ctx.imageSmoothingEnabled = true;
+  ctx.drawImage(
+    item.image,
+    offsets.left,
+    offsets.top,
+    cropWidth,
+    cropHeight,
+    0,
+    0,
+    canvasWidth,
+    canvasHeight,
+  );
+
+  previewSize.textContent = `Обрезанный размер: ${cropWidth} × ${cropHeight} px`;
+}
+
+function removeImageItem(id) {
+  const index = state.items.findIndex((image) => image.id === id);
+  if (index === -1) return;
+
+  const [item] = state.items.splice(index, 1);
+  item.elements.card.remove();
+  updateDownloadButtonState();
+}
+
+function updateDownloadButtonState() {
+  downloadButton.disabled = state.items.length === 0;
+}
+
+async function handleDownloadAll() {
+  if (!state.items.length) {
+    return;
+  }
+
+  const rawMaxDimension = Number(maxDimensionInput.value);
+  const maxDimension = Number.isFinite(rawMaxDimension) && rawMaxDimension > 0 ? Math.round(rawMaxDimension) : 500;
+
+  const baseNameRaw = baseNameInput.value.trim();
+  const baseName = baseNameRaw ? baseNameRaw.replace(/\s+/g, '_') : 'card';
+
+  let index = Number.parseInt(startIndexInput.value, 10);
+  if (Number.isNaN(index)) {
+    index = 1;
+  }
+
+  downloadButton.disabled = true;
+  const originalText = downloadButton.textContent;
+  downloadButton.textContent = 'Сохранение…';
+
+  try {
+    for (const item of state.items) {
+      const blob = await exportImage(item, maxDimension);
+      const link = document.createElement('a');
+      link.href = URL.createObjectURL(blob);
+      link.download = `${baseName}${index}.jpg`;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      setTimeout(() => URL.revokeObjectURL(link.href), 2000);
+      index += 1;
+    }
+  } catch (error) {
+    console.error('Не удалось сохранить изображения', error);
+  } finally {
+    downloadButton.disabled = state.items.length === 0;
+    downloadButton.textContent = originalText;
+    startIndexInput.value = String(index);
+  }
+}
+
+function exportImage(item, maxDimension) {
+  return new Promise((resolve, reject) => {
+    const { offsets } = item;
+    const cropWidth = Math.max(1, item.width - offsets.left - offsets.right);
+    const cropHeight = Math.max(1, item.height - offsets.top - offsets.bottom);
+
+    const cropCanvas = document.createElement('canvas');
+    cropCanvas.width = cropWidth;
+    cropCanvas.height = cropHeight;
+    const cropCtx = cropCanvas.getContext('2d');
+    cropCtx.imageSmoothingEnabled = true;
+    cropCtx.drawImage(
+      item.image,
+      offsets.left,
+      offsets.top,
+      cropWidth,
+      cropHeight,
+      0,
+      0,
+      cropWidth,
+      cropHeight,
+    );
+
+    let targetCanvas = cropCanvas;
+
+    const longestSide = Math.max(cropWidth, cropHeight);
+    if (longestSide > maxDimension) {
+      const scale = maxDimension / longestSide;
+      const scaledWidth = Math.max(1, Math.round(cropWidth * scale));
+      const scaledHeight = Math.max(1, Math.round(cropHeight * scale));
+      targetCanvas = document.createElement('canvas');
+      targetCanvas.width = scaledWidth;
+      targetCanvas.height = scaledHeight;
+      const targetCtx = targetCanvas.getContext('2d');
+      targetCtx.imageSmoothingEnabled = true;
+      targetCtx.drawImage(cropCanvas, 0, 0, scaledWidth, scaledHeight);
+    }
+
+    targetCanvas.toBlob(
+      (blob) => {
+        if (blob) {
+          resolve(blob);
+        } else {
+          reject(new Error('Не удалось создать JPG'));
+        }
+      },
+      'image/jpeg',
+      0.92,
+    );
+  });
+}
+
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Обрезка PNG и сохранение в JPG</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <main class="container">
+    <header class="page-header">
+      <h1>Обрезка PNG и экспорт в JPG</h1>
+      <p class="lead">
+        Загрузите изображения с белым фоном, настройте рамку обрезки и сохраните их в формате JPG с нужным именованием.
+      </p>
+    </header>
+
+    <section class="controls" aria-label="Настройки">
+      <div class="control-group">
+        <label class="file-label" for="fileInput">Выберите изображения</label>
+        <input id="fileInput" type="file" accept="image/png,image/jpeg,image/webp,image/*" multiple />
+      </div>
+
+      <div class="control-row">
+        <label>
+          Максимальная сторона (px)
+          <input id="maxDimension" type="number" min="50" max="4000" value="500" />
+        </label>
+        <label>
+          Имя файлов
+          <input id="baseName" type="text" value="card" placeholder="Например, card" />
+        </label>
+        <label>
+          Номер для начала
+          <input id="startIndex" type="number" min="0" value="1" />
+        </label>
+      </div>
+
+      <button id="downloadAll" type="button" disabled>Скачать все JPG</button>
+    </section>
+
+    <section id="imagesContainer" class="images" aria-live="polite"></section>
+  </main>
+
+  <template id="imageTemplate">
+    <article class="image-card">
+      <header class="image-card__header">
+        <div>
+          <h2 class="image-card__title"></h2>
+          <p class="image-card__subtitle"></p>
+        </div>
+        <button type="button" class="remove-btn" title="Удалить изображение">×</button>
+      </header>
+
+      <canvas class="preview" width="240" height="180" aria-label="Предпросмотр обрезки"></canvas>
+      <p class="preview-size"></p>
+
+      <div class="mode-switch">
+        <label>
+          <input type="checkbox" class="manual-toggle" />
+          Ручная настройка обрезки
+        </label>
+        <button type="button" class="reset-auto">Автообрезка</button>
+      </div>
+
+      <div class="sliders" hidden>
+        <div class="slider">
+          <label>Сверху: <span class="value value-top"></span> px</label>
+          <input type="range" class="slider-top" min="0" value="0" />
+        </div>
+        <div class="slider">
+          <label>Снизу: <span class="value value-bottom"></span> px</label>
+          <input type="range" class="slider-bottom" min="0" value="0" />
+        </div>
+        <div class="slider">
+          <label>Слева: <span class="value value-left"></span> px</label>
+          <input type="range" class="slider-left" min="0" value="0" />
+        </div>
+        <div class="slider">
+          <label>Справа: <span class="value value-right"></span> px</label>
+          <input type="range" class="slider-right" min="0" value="0" />
+        </div>
+      </div>
+    </article>
+  </template>
+
+  <script src="app.js" type="module"></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,261 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Inter", "Segoe UI", Roboto, sans-serif;
+  line-height: 1.4;
+  --accent: #3f8cff;
+  --accent-dark: #1f6bdb;
+  --border-color: rgba(0, 0, 0, 0.1);
+  --bg-muted: rgba(63, 140, 255, 0.08);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  background: #f6f7fb;
+  color: #1c1c1c;
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background: #10131a;
+    color: #f1f3f9;
+  }
+
+  .image-card,
+  .controls {
+    background: rgba(22, 25, 35, 0.75);
+    border-color: rgba(255, 255, 255, 0.08);
+  }
+}
+
+.container {
+  margin: 0 auto;
+  padding: 2rem clamp(1rem, 3vw, 2.5rem) 3rem;
+  max-width: 1024px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.page-header h1 {
+  margin: 0;
+  font-size: clamp(1.4rem, 4vw, 2.4rem);
+}
+
+.lead {
+  margin: 0.5rem 0 0;
+  max-width: 60ch;
+  color: rgba(28, 28, 28, 0.75);
+}
+
+@media (prefers-color-scheme: dark) {
+  .lead {
+    color: rgba(241, 243, 249, 0.7);
+  }
+}
+
+.controls {
+  background: #fff;
+  border: 1px solid var(--border-color);
+  border-radius: 16px;
+  padding: 1.25rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem 2rem;
+  align-items: flex-end;
+}
+
+.control-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.control-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.control-row label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.95rem;
+}
+
+input[type="file"] {
+  border: 1px dashed var(--border-color);
+  padding: 0.75rem;
+  border-radius: 12px;
+  background: rgba(63, 140, 255, 0.04);
+  color: inherit;
+}
+
+input[type="number"],
+input[type="text"] {
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  padding: 0.5rem 0.75rem;
+  font-size: 1rem;
+  background: rgba(255, 255, 255, 0.92);
+  color: inherit;
+}
+
+button {
+  border: none;
+  border-radius: 10px;
+  padding: 0.6rem 1.2rem;
+  font-size: 1rem;
+  font-weight: 600;
+  background: var(--accent);
+  color: #fff;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+button:disabled {
+  background: rgba(0, 0, 0, 0.2);
+  cursor: not-allowed;
+}
+
+button:not(:disabled):hover,
+button:not(:disabled):focus-visible {
+  background: var(--accent-dark);
+}
+
+#downloadAll {
+  margin-left: auto;
+}
+
+.images {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+}
+
+.image-card {
+  background: #fff;
+  border: 1px solid var(--border-color);
+  border-radius: 18px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  position: relative;
+}
+
+.image-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.image-card__title {
+  margin: 0;
+  font-size: 1.05rem;
+  word-break: break-word;
+}
+
+.image-card__subtitle {
+  margin: 0.2rem 0 0;
+  font-size: 0.85rem;
+  color: rgba(28, 28, 28, 0.65);
+}
+
+.remove-btn {
+  background: rgba(255, 71, 87, 0.16);
+  color: #ff4757;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  font-size: 1.3rem;
+  line-height: 1;
+  padding: 0;
+}
+
+.remove-btn:hover,
+.remove-btn:focus-visible {
+  background: rgba(255, 71, 87, 0.28);
+}
+
+.preview {
+  width: 100%;
+  border-radius: 12px;
+  background: var(--bg-muted);
+  display: block;
+}
+
+.preview-size {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(28, 28, 28, 0.7);
+}
+
+.mode-switch {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.mode-switch label {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.95rem;
+}
+
+.mode-switch input[type="checkbox"] {
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.reset-auto {
+  background: rgba(63, 140, 255, 0.16);
+  color: var(--accent-dark);
+  font-weight: 600;
+}
+
+.reset-auto:hover,
+.reset-auto:focus-visible {
+  background: rgba(63, 140, 255, 0.28);
+}
+
+.sliders {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.slider label {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.9rem;
+}
+
+.slider input[type="range"] {
+  width: 100%;
+  accent-color: var(--accent);
+}
+
+@media (max-width: 640px) {
+  .controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  #downloadAll {
+    margin-left: 0;
+  }
+
+  .mode-switch {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}


### PR DESCRIPTION
## Summary
- add a standalone web page that loads multiple images, auto-detects white borders, and crops previews
- enable manual fine-tuning of crop margins plus configurable max side and filename sequencing for JPG export
- style the interface responsively for comfortable use on mobile and desktop

## Testing
- Manual testing in browser


------
https://chatgpt.com/codex/tasks/task_e_68d9fae7e830832eae3a4f74bcbfd3ee