### PR TITLE
Improve batch download reliability and auto-cropping

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,15 +5,27 @@ const startIndexInput = document.getElementById('startIndex');
 const downloadButton = document.getElementById('downloadAll');
 const imagesContainer = document.getElementById('imagesContainer');
 const imageTemplate = document.getElementById('imageTemplate');
+const thresholdInput = document.getElementById('whiteThreshold');
+const matchFirstCropCheckbox = document.getElementById('matchFirstCrop');
 
 const MIN_CROP_PIXELS = 1;
-const WHITE_THRESHOLD = 248;
-const WHITE_ROW_TOLERANCE = 0.97;
+const DEFAULT_WHITE_THRESHOLD = 252;
+const WHITE_THRESHOLD_MIN = 200;
+const WHITE_THRESHOLD_MAX = 254;
+const WHITE_ROW_TOLERANCE = 0.995;
 const DOWNLOAD_DELAY_MS = 180;
 
 const state = {
   items: [],
+  whiteThreshold: DEFAULT_WHITE_THRESHOLD,
+  applyFirstCrop: false,
 };
+
+if (thresholdInput) {
+  const initial = sanitizeWhiteThreshold(thresholdInput.value);
+  state.whiteThreshold = initial;
+  thresholdInput.value = String(initial);
+}
 
 fileInput.addEventListener('change', (event) => {
   const files = Array.from(event.target.files || []);
@@ -27,6 +39,34 @@ fileInput.addEventListener('change', (event) => {
 });
 
 downloadButton.addEventListener('click', handleDownloadAll);
+
+if (thresholdInput) {
+  const handle = () => {
+    const newValue = sanitizeWhiteThreshold(thresholdInput.value);
+    state.whiteThreshold = newValue;
+    thresholdInput.value = String(newValue);
+    recomputeAutoOffsets();
+  };
+  thresholdInput.addEventListener('input', handle);
+  thresholdInput.addEventListener('change', handle);
+}
+
+if (matchFirstCropCheckbox) {
+  matchFirstCropCheckbox.addEventListener('change', () => {
+    state.applyFirstCrop = matchFirstCropCheckbox.checked;
+    if (state.applyFirstCrop) {
+      applyReferenceCrop();
+    } else {
+      state.items.forEach((item) => {
+        if (!item.isManual) {
+          item.offsets = { ...item.autoOffsets };
+        }
+        updateSliderUI(item);
+        updatePreview(item);
+      });
+    }
+  });
+}
 
 function loadImageFile(file) {
   const reader = new FileReader();
@@ -49,6 +89,10 @@ function loadImageFile(file) {
       state.items.push(item);
       updateDownloadButtonState();
       updatePreview(item);
+
+      if (state.applyFirstCrop) {
+        applyReferenceCrop();
+      }
     };
     img.onerror = () => {
       console.error('Не удалось прочитать изображение:', file.name);
@@ -61,7 +105,7 @@ function loadImageFile(file) {
   reader.readAsDataURL(file);
 }
 
-function detectAutoOffsets(image) {
+function detectAutoOffsets(image, thresholdOverride = state.whiteThreshold) {
   const width = image.naturalWidth;
   const height = image.naturalHeight;
   const canvas = document.createElement('canvas');
@@ -71,7 +115,12 @@ function detectAutoOffsets(image) {
   ctx.drawImage(image, 0, 0);
   const { data } = ctx.getImageData(0, 0, width, height);
 
-  const whiteThreshold = WHITE_THRESHOLD;
+  const thresholdBase = Number(thresholdOverride);
+  const whiteThreshold = clamp(
+    Number.isFinite(thresholdBase) ? Math.round(thresholdBase) : state.whiteThreshold,
+    WHITE_THRESHOLD_MIN,
+    WHITE_THRESHOLD_MAX,
+  );
   const tolerance = WHITE_ROW_TOLERANCE;
   const sampleX = Math.max(1, Math.floor(width / 600));
   const sampleY = Math.max(1, Math.floor(height / 600));
@@ -81,14 +130,19 @@ function detectAutoOffsets(image) {
     const r = data[index];
     const g = data[index + 1];
     const b = data[index + 2];
-    const minChannel = Math.min(r, g, b);
-    const maxChannel = Math.max(r, g, b);
     const luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b;
-    return (
-      minChannel >= whiteThreshold - 5 &&
-      maxChannel >= whiteThreshold &&
-      luminance >= whiteThreshold - 3
-    );
+
+    if (luminance < whiteThreshold) {
+      return false;
+    }
+
+    const minChannel = Math.min(r, g, b);
+    if (minChannel >= whiteThreshold - 12) {
+      return true;
+    }
+
+    const maxChannel = Math.max(r, g, b);
+    return maxChannel >= whiteThreshold + 4 && minChannel >= whiteThreshold - 20;
   };
 
   const rowIsWhite = (y) => {
@@ -261,13 +315,24 @@ function setManualMode(item, manual) {
     slider.disabled = !manual;
   });
 
+  manualToggle.checked = manual;
   if (!manual) {
-    item.offsets = { ...item.autoOffsets };
+    if (state.applyFirstCrop) {
+      applyReferenceCrop();
+    } else {
+      item.offsets = { ...item.autoOffsets };
+      updateSliderUI(item);
+      updatePreview(item);
+    }
+    return;
   }
 
-  manualToggle.checked = manual;
   updateSliderUI(item);
   updatePreview(item);
+
+  if (state.applyFirstCrop && item.isManual && isReferenceItem(item)) {
+    applyReferenceCrop();
+  }
 }
 
 function applyOffsetChange(item, side, value) {
@@ -355,6 +420,10 @@ function removeImageItem(id) {
   const [item] = state.items.splice(index, 1);
   item.elements.card.remove();
   updateDownloadButtonState();
+
+  if (state.applyFirstCrop) {
+    applyReferenceCrop();
+  }
 }
 
 function updateDownloadButtonState() {
@@ -467,6 +536,133 @@ function exportImage(item, maxDimension) {
       0.92,
     );
   });
+}
+
+function sanitizeWhiteThreshold(rawValue) {
+  const numeric = typeof rawValue === 'number' ? rawValue : Number(rawValue);
+  if (!Number.isFinite(numeric)) {
+    return DEFAULT_WHITE_THRESHOLD;
+  }
+  const rounded = Math.round(numeric);
+  return clamp(rounded, WHITE_THRESHOLD_MIN, WHITE_THRESHOLD_MAX);
+}
+
+function recomputeAutoOffsets() {
+  if (!state.items.length) {
+    return;
+  }
+
+  state.items.forEach((item) => {
+    const autoOffsets = detectAutoOffsets(item.image, state.whiteThreshold);
+    item.autoOffsets = { ...autoOffsets };
+  });
+
+  if (state.applyFirstCrop) {
+    applyReferenceCrop();
+    return;
+  }
+
+  state.items.forEach((item) => {
+    if (!item.isManual) {
+      item.offsets = { ...item.autoOffsets };
+    }
+    updateSliderUI(item);
+    updatePreview(item);
+  });
+}
+
+function applyReferenceCrop() {
+  const reference = getReferenceItem();
+  if (!reference) {
+    return;
+  }
+
+  if (!reference.isManual) {
+    reference.offsets = { ...reference.autoOffsets };
+  }
+  const template = { ...reference.offsets };
+
+  state.items.forEach((item, index) => {
+    if (index === 0) {
+      updateSliderUI(reference);
+      updatePreview(reference);
+      return;
+    }
+
+    if (item.isManual) {
+      updateSliderUI(item);
+      updatePreview(item);
+      return;
+    }
+
+    const adaptedOffsets = adaptOffsetsToItem(template, item);
+    item.offsets = adaptedOffsets;
+    updateSliderUI(item);
+    updatePreview(item);
+  });
+}
+
+function adaptOffsetsToItem(templateOffsets, item) {
+  const { width, height } = item;
+  const safeTemplate = {
+    top: templateOffsets.top ?? 0,
+    bottom: templateOffsets.bottom ?? 0,
+    left: templateOffsets.left ?? 0,
+    right: templateOffsets.right ?? 0,
+  };
+
+  let top = clamp(Math.round(safeTemplate.top), 0, Math.max(0, height - MIN_CROP_PIXELS));
+  let bottom = clamp(Math.round(safeTemplate.bottom), 0, Math.max(0, height - MIN_CROP_PIXELS));
+  let left = clamp(Math.round(safeTemplate.left), 0, Math.max(0, width - MIN_CROP_PIXELS));
+  let right = clamp(Math.round(safeTemplate.right), 0, Math.max(0, width - MIN_CROP_PIXELS));
+
+  [top, bottom] = fitPairToLimit(top, bottom, Math.max(0, height - MIN_CROP_PIXELS));
+  [left, right] = fitPairToLimit(left, right, Math.max(0, width - MIN_CROP_PIXELS));
+
+  return { top, bottom, left, right };
+}
+
+function fitPairToLimit(first, second, limit) {
+  if (limit <= 0) {
+    return [0, 0];
+  }
+
+  let a = clamp(first, 0, limit);
+  let b = clamp(second, 0, limit);
+  let total = a + b;
+
+  if (total <= limit) {
+    return [a, b];
+  }
+
+  const overflow = total - limit;
+  if (overflow > 0) {
+    const reduceA = Math.round((overflow * (a || 0)) / (total || 1));
+    const reduceB = overflow - reduceA;
+    a = clamp(a - reduceA, 0, limit);
+    b = clamp(b - reduceB, 0, limit);
+    total = a + b;
+    if (total > limit) {
+      const extra = total - limit;
+      if (b >= extra) {
+        b = clamp(b - extra, 0, limit);
+      } else {
+        a = clamp(a - (extra - b), 0, limit);
+        b = 0;
+      }
+    }
+  }
+
+  return [a, b];
+}
+
+function getReferenceItem() {
+  return state.items[0] || null;
+}
+
+function isReferenceItem(item) {
+  const reference = getReferenceItem();
+  return Boolean(reference && reference.id === item.id);
 }
 
 function clamp(value, min, max) {

--- a/index.html
+++ b/index.html
@@ -36,6 +36,18 @@
         </label>
       </div>
 
+      <div class="control-row">
+        <label>
+          Порог белого (0-255)
+          <input id="whiteThreshold" type="number" min="200" max="254" value="252" step="1" />
+          <span class="control-hint">Регулируйте, чтобы сильнее или слабее обрезать светлый фон.</span>
+        </label>
+        <label class="checkbox-label">
+          <input id="matchFirstCrop" type="checkbox" />
+          Обрезать по первому изображению
+        </label>
+      </div>
+
       <button id="downloadAll" type="button" disabled>Скачать все JPG</button>
     </section>
 

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
       <div class="control-row">
         <label>
           Максимальная сторона (px)
-          <input id="maxDimension" type="number" min="50" max="4000" value="500" />
+          <input id="maxDimension" type="number" min="50" max="4000" value="700" />
         </label>
         <label>
           Имя файлов

--- a/styles.css
+++ b/styles.css
@@ -88,6 +88,28 @@ body {
   font-size: 0.95rem;
 }
 
+.checkbox-label {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+}
+
+.checkbox-label input[type="checkbox"] {
+  margin: 0;
+}
+
+.control-hint {
+  font-size: 0.75rem;
+  color: rgba(28, 28, 28, 0.6);
+}
+
+@media (prefers-color-scheme: dark) {
+  .control-hint {
+    color: rgba(241, 243, 249, 0.55);
+  }
+}
+
 input[type="file"] {
   border: 1px dashed var(--border-color);
   padding: 0.75rem;

--- a/styles.css
+++ b/styles.css
@@ -6,6 +6,8 @@
   --accent-dark: #1f6bdb;
   --border-color: rgba(0, 0, 0, 0.1);
   --bg-muted: rgba(63, 140, 255, 0.08);
+  --preview-border: rgba(0, 0, 0, 0.85);
+  --preview-bg: #fff;
 }
 
 * {
@@ -29,6 +31,11 @@ body {
   .controls {
     background: rgba(22, 25, 35, 0.75);
     border-color: rgba(255, 255, 255, 0.08);
+  }
+
+  :root {
+    --preview-border: rgba(255, 255, 255, 0.85);
+    --preview-bg: rgba(10, 14, 22, 0.85);
   }
 }
 
@@ -208,8 +215,9 @@ button:not(:disabled):focus-visible {
 
 .preview {
   width: 100%;
-  border-radius: 12px;
-  background: var(--bg-muted);
+  border-radius: 0;
+  background: var(--preview-bg);
+  border: 2px solid var(--preview-border);
   display: block;
 }
 


### PR DESCRIPTION
## Summary
- tighten automatic white-background detection to capture residual margins
- ensure large batches of JPG exports finish by pacing sequential downloads
- set the default export size field to 700 px on the long side

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddd91719dc832e84a17645a3e8f67a